### PR TITLE
Add simple GitHub Pages landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Välkommen till Min GitHub Pages-sida</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <h1 class="site-title">Min GitHub Pages-sida</h1>
+        <nav>
+          <ul class="nav-list">
+            <li><a href="#intro">Start</a></li>
+            <li><a href="#projects">Projekt</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section id="intro" class="hero">
+        <div class="container">
+          <h2>Hej! Jag heter Alex</h2>
+          <p>
+            Det här är en enkel GitHub Pages-webbplats skapad som ett exempel på hur
+            man kan presentera projekt, skriva en kort presentation och erbjuda en
+            kontaktväg.
+          </p>
+          <a class="cta" href="#projects">Utforska projekten</a>
+        </div>
+      </section>
+
+      <section id="projects" class="section">
+        <div class="container">
+          <h2>Projekt</h2>
+          <div class="grid">
+            <article class="card">
+              <h3>Portfolio</h3>
+              <p>
+                En personlig portfölj som visar upp mina bästa designer och
+                utvecklingsprojekt.
+              </p>
+              <a href="#" aria-label="Läs mer om portföljen">Läs mer</a>
+            </article>
+            <article class="card">
+              <h3>Blogg</h3>
+              <p>
+                En blogg där jag delar guider och tips om webbutveckling och
+                produktivitet.
+              </p>
+              <a href="#" aria-label="Läs mer om bloggen">Läs mer</a>
+            </article>
+            <article class="card">
+              <h3>Öppna källkod</h3>
+              <p>
+                Små open-source projekt som hjälper andra utvecklare komma igång
+                med nya idéer.
+              </p>
+              <a href="#" aria-label="Läs mer om öppna källkodsprojekt">Läs mer</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="section section--alt">
+        <div class="container">
+          <h2>Om Mig</h2>
+          <p>
+            Jag är en utvecklare som älskar att skapa snygga, snabba och
+            tillgängliga webbplatser. När jag inte kodar hittar du mig i skogen,
+            med en bok eller i köket där jag testar nya recept.
+          </p>
+        </div>
+      </section>
+
+      <section id="contact" class="section">
+        <div class="container">
+          <h2>Kontakt</h2>
+          <p>
+            Har du frågor eller vill du samarbeta? Tveka inte att höra av dig!
+          </p>
+          <a class="cta" href="mailto:alex@example.com">Skicka ett mail</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>© <span id="year"></span> Alex Demo. Byggd med GitHub Pages.</p>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,164 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --shadow: 0 20px 45px -20px rgba(15, 23, 42, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.site-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.hero {
+  padding: 6rem 0 5rem;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(79, 70, 229, 0.1));
+}
+
+.hero h2 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  max-width: 620px;
+  margin: 0 auto 2rem;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.section--alt {
+  background: var(--surface);
+}
+
+.section h2 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  padding: 2rem;
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.3rem;
+}
+
+.card p {
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.cta {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.9rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  background: var(--accent-dark);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem 0 2.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .site-header .container {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .nav-list {
+    gap: 1rem;
+  }
+
+  .hero {
+    padding: 5rem 0 4rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Swedish GitHub Pages landing page with intro, project highlights, about and contact sections
- create responsive styling with typography, layout and call-to-action button treatments

## Testing
- Manual: Viewed `index.html` in a local browser via `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68d70d37fbec8333a4def61abe9fdab6